### PR TITLE
Add track-based callback with shuffle per track

### DIFF
--- a/src/uClock.cpp
+++ b/src/uClock.cpp
@@ -1,8 +1,8 @@
 /*!
  *  @file       uClock.cpp
  *  Project     BPM clock generator for Arduino
- *  @brief      A Library to implement BPM clock tick calls using hardware interruption. Supported and tested on AVR boards(ATmega168/328, ATmega16u4/32u4 and ATmega2560) and ARM boards(Teensy, Seedstudio XIAO M0 and ESP32)
- *  @version    2.0.0
+ *  @brief      A Library to implement BPM clock tick calls using hardware interruption. Supported and tested on AVR boards(ATmega168/328, ATmega16u4/32u4 and ATmega2560) and ARM boards(RPI2040, Teensy, Seedstudio XIAO M0 and ESP32)
+ *  @version    2.2.0
  *  @author     Romulo Silva
  *  @date       10/06/2017
  *  @license    MIT - (c) 2024 - Romulo Silva - contact@midilab.co
@@ -56,6 +56,12 @@
 //
 #if defined(ARDUINO_ARCH_STM32)
     #include "platforms/stm32.h"
+#endif
+//
+// RP2040 (Raspberry Pico) family
+//
+#if defined(ARDUINO_ARCH_RP2040)
+    #include "platforms/rp2040.h"
 #endif
 
 //

--- a/src/uClock.cpp
+++ b/src/uClock.cpp
@@ -364,8 +364,11 @@ bool inline uClockClass::processShuffle()
     if (shff >= 0) {
         mod_shuffle = mod_step_counter - shff;
         // any late shuffle? we should skip next mod_step_counter == 0
-        if (last_shff < 0 && mod_step_counter != 1)
-            return false; 
+        if (last_shff < 0 && mod_step_counter != 1) {
+            if (shuffle_shoot_ctrl == true)
+                shuffle_shoot_ctrl = false;
+            return false;
+        }
     } else if (shff < 0) {
         mod_shuffle = mod_step_counter - (mod_step_ref + shff);
         //if (last_shff < 0 && mod_step_counter != 1)

--- a/src/uClock.cpp
+++ b/src/uClock.cpp
@@ -400,35 +400,40 @@ bool inline uClockClass::processTrackShuffle(uint8_t track)
 
     // check shuffle template of current
     int8_t shff = track_shuffles[track].shuffle.step[track_step_counter[track]%track_shuffles[track].shuffle.size];
-
+    
     if (track_shuffles[track].shuffle_shoot_ctrl == false && mod_track_step_counter[track] == 0)
-        track_shuffles[track].shuffle_shoot_ctrl = true; 
-
-    //if (mod_track_step_counter[track] == mod_step_ref-1)
+        track_shuffles[track].shuffle_shoot_ctrl = true;
 
     if (shff >= 0) {
         mod_shuffle = mod_track_step_counter[track] - shff;
+
         // any late shuffle? we should skip next mod_track_step_counter == 0
-        if (track_shuffles[track].last_shff < 0 && mod_track_step_counter[track] != 1)
-            return false; 
+        if (track_shuffles[track].last_shff < 0 && mod_track_step_counter[track] != 1) {           
+            if (track_shuffles[track].shuffle_shoot_ctrl == true)
+                track_shuffles[track].shuffle_shoot_ctrl = false;
+
+            return false;
+        }
+
     } else if (shff < 0) {
         mod_shuffle = mod_track_step_counter[track] - (mod_step_ref + shff);
-        //if (last_shff < 0 && mod_track_step_counter[track] != 1)
-        //    return false; 
+
         track_shuffles[track].shuffle_shoot_ctrl = true;
     }
 
     track_shuffles[track].last_shff = shff;
 
     // shuffle_shoot_ctrl helps keep track if we have shoot or not a note for the step space of ppqn/4 pulses
-    if (mod_shuffle == 0 && track_shuffles[track].shuffle_shoot_ctrl == true) {
-        // keep track of next note shuffle for current note lenght control
+    if (mod_shuffle == 0 && track_shuffles[track].shuffle_shoot_ctrl == true) {        
+        track_shuffles[track].shuffle_shoot_ctrl = false;
+
+        // // keep track of next note shuffle for current note lenght control
         track_shuffles[track].shuffle_length_ctrl = track_shuffles[track].shuffle.step[(track_step_counter[track]+1)%track_shuffles[track].shuffle.size];
         if (shff > 0)
             track_shuffles[track].shuffle_length_ctrl -= shff;
         if (shff < 0)
             track_shuffles[track].shuffle_length_ctrl += shff;
-        track_shuffles[track].shuffle_shoot_ctrl = false;
+
         return true;
     }
 

--- a/src/uClock.h
+++ b/src/uClock.h
@@ -205,6 +205,7 @@ class uClockClass {
         uint8_t mod24_counter;
         uint8_t mod24_ref;
         uint8_t mod_step_counter;
+        uint8_t mod_track_step_counter[MAX_TRACKS];
         uint8_t mod_step_ref;
         uint32_t step_counter; // should we go uint16_t?
         uint32_t track_step_counter[MAX_TRACKS];

--- a/src/uClock.h
+++ b/src/uClock.h
@@ -1,8 +1,8 @@
 /*!
  *  @file       uClock.h
  *  Project     BPM clock generator for Arduino
- *  @brief      A Library to implement BPM clock tick calls using hardware interruption. Supported and tested on AVR boards(ATmega168/328, ATmega16u4/32u4 and ATmega2560) and ARM boards(Teensy, Seedstudio XIAO M0 and ESP32)
- *  @version    2.0.0
+ *  @brief      A Library to implement BPM clock tick calls using hardware interruption. Supported and tested on AVR boards(ATmega168/328, ATmega16u4/32u4 and ATmega2560) and ARM boards(RPI2040, Teensy, Seedstudio XIAO M0 and ESP32)
+ *  @version    2.2.0
  *  @author     Romulo Silva
  *  @date       10/06/2017
  *  @license    MIT - (c) 2024 - Romulo Silva - contact@midilab.co


### PR DESCRIPTION
I created an [issue](https://github.com/midilab/uClock/issues/41) with a feature request for essentially doing a track-based callback and shuffle while still tethered to the main clock, so as not to generate multiple instances of uClock and having to synchronize them.

This allows track-based sequencers which use uClock to have track-based control over step counting and shuffle settings. This enables things like applying microtiming/shuffle on steps for individual tracks, rather than microtiming/shuffle on steps for a pattern as a whole.