### PR TITLE
Feature: pause+continue

### DIFF
--- a/src/uClock.cpp
+++ b/src/uClock.cpp
@@ -183,13 +183,24 @@ void uClockClass::stop()
     }
 }
 
+void uClockClass::continue_playing() {
+    if (state == PAUSED) {
+        start_timer = millis();
+        if (mode == INTERNAL_CLOCK) {
+            state = STARTED;
+        } else {
+            state = STARTING;
+        }
+    }
+}
+
 void uClockClass::pause() 
 {
     if (mode == INTERNAL_CLOCK) {
         if (state == PAUSED) {
-            start();
+            continue_playing();
         } else {
-            stop();
+            state = PAUSED;
         }
     }
 }

--- a/src/uClock.cpp
+++ b/src/uClock.cpp
@@ -191,6 +191,9 @@ void uClockClass::continue_playing() {
         } else {
             state = STARTING;
         }
+        if (onClockContinueCallback) {
+            onClockContinueCallback();
+        }
     }
 }
 
@@ -201,6 +204,9 @@ void uClockClass::pause()
             continue_playing();
         } else {
             state = PAUSED;
+            if (onClockPauseCallback) {
+                onClockPauseCallback();
+            }
         }
     }
 }

--- a/src/uClock.h
+++ b/src/uClock.h
@@ -116,6 +116,14 @@ class uClockClass {
             onClockStopCallback = callback;
         }
 
+        void setOnClockContinue(void (*callback)()) {
+            onClockStartCallback = callback;
+        }
+
+        void setOnClockPause(void (*callback)()) {
+            onClockPauseCallback = callback;
+        }
+
         void init();
         void setPPQN(PPQNResolution resolution);
 
@@ -172,6 +180,8 @@ class uClockClass {
         void (*onSync24Callback)(uint32_t tick);
         void (*onClockStartCallback)();
         void (*onClockStopCallback)();
+        void (*onClockContinueCallback)();
+        void (*onClockPauseCallback)();
 
         // internal clock control
         // uint16_t ppqn;

--- a/src/uClock.h
+++ b/src/uClock.h
@@ -127,6 +127,7 @@ class uClockClass {
         void start();
         void stop();
         void pause();
+        void continue_playing();
         void setTempo(float bpm);
         float getTempo();
 


### PR DESCRIPTION
As discussed in #49, implements ability to pause + continue on internal clock.  

Not sure how this will affect external clocks -- probably won't work well, may need some thought..

Also added user callbacks via _setOnClockPause_ and _setOnClockContinue_ for when paused and continued, although haven't tested these.

Mostly submitting this as a pull request in hopes it will find its way into main branch sooner, since things in my development environment are getting messy now that I have multiple branches for new features (like #41) that my own libraries are starting to rely on😅 